### PR TITLE
Mouse Right Click Camera Panning Movement. 

### DIFF
--- a/HorizonEditor/src/EditorLayer.cpp
+++ b/HorizonEditor/src/EditorLayer.cpp
@@ -72,7 +72,6 @@ void EditorLayer::onUpdate(Hzn::TimeStep ts)
 	Hzn::RenderCall::setClearColor({ 0.1f, 0.1f, 0.1f, 1.0f });
 	Hzn::RenderCall::submitClear();
 
-	/*Hzn::Renderer2D::beginScene(m_CameraController.getCamera());*/
 	// update the scene.
 	if (EditorData::s_Scene_Active) {
 		if (m_PlayMode)
@@ -80,8 +79,6 @@ void EditorLayer::onUpdate(Hzn::TimeStep ts)
 		else
 			EditorData::s_Scene_Active->onEditorUpdate(m_EditorCameraController.getCamera(), ts);
 	}
-	// unbind the current framebuffer.
-	/*Hzn::Renderer2D::endScene();*/
 
 	// checking if the mouse pointer is hovering on the viewport, and retrieving the right position.
 	auto mousePos = ImGui::GetMousePos();
@@ -90,21 +87,22 @@ void EditorLayer::onUpdate(Hzn::TimeStep ts)
 
 	auto viewportSize = m_ViewportBounds[1] - m_ViewportBounds[0];
 
-	if(0 < mousePos.x && mousePos.x < viewportSize.x  && 0 < mousePos.y && mousePos.y < viewportSize.y)
-		HZN_INFO("{0}, {1}", mousePos.x, mousePos.y);
-
+	if (0 < mousePos.x && mousePos.x < viewportSize.x && 0 < mousePos.y && mousePos.y < viewportSize.y)
+	{
+		/*HZN_INFO("{0}, {1}", mousePos.x, mousePos.y);*/
+	}
+	// unbind the current framebuffer.
 	m_FrameBuffer->unbind();
 }
 
 void EditorLayer::onEvent(Hzn::Event& e)
 {
+	Hzn::EventDispatcher dispatcher(e);
+	dispatcher.Dispatch<Hzn::KeyPressedEvent>(std::bind(&EditorLayer::onKeyPressed, this, std::placeholders::_1));
 	if (m_ViewportFocused && m_ViewportHovered && !m_PlayMode) {
 		m_EditorCameraController.onEvent(e);
 	}
 
-	Hzn::EventDispatcher dispatcher(e);
-
-	dispatcher.Dispatch<Hzn::KeyPressedEvent>(std::bind(&EditorLayer::onKeyPressed, this, std::placeholders::_1));
 }
 
 
@@ -711,17 +709,17 @@ bool EditorLayer::onKeyPressed(Hzn::KeyPressedEvent& e)
 		m_GizmoType = ImGuizmo::OPERATION::NONE;
 		break;
 	}
-	case Hzn::Key::E:
+	case Hzn::Key::W:
 	{
 		m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
 		break;
 	}
-	case Hzn::Key::R:
+	case Hzn::Key::E:
 	{
 		m_GizmoType = ImGuizmo::OPERATION::ROTATE;
 		break;
 	}
-	case Hzn::Key::T:
+	case Hzn::Key::R:
 	{
 		m_GizmoType = ImGuizmo::OPERATION::SCALE;
 		break;

--- a/HorizonEngine/src/HorizonEngine/Camera/CameraController.cpp
+++ b/HorizonEngine/src/HorizonEngine/Camera/CameraController.cpp
@@ -5,7 +5,7 @@ namespace Hzn
 {
 	void OrthographicCameraController::onUpdate(TimeStep ts)
 	{
-		if (Hzn::Input::keyPressed(Hzn::Key::W))
+		/*if (Hzn::Input::keyPressed(Hzn::Key::W))
 		{
 			m_Position.y += (m_TranslationSpeed * ts);
 		}
@@ -20,45 +20,14 @@ namespace Hzn
 		else if (Hzn::Input::keyPressed(Hzn::Key::D))
 		{
 			m_Position.x += (m_TranslationSpeed * ts);
-		}
+		}*/
 
-
-		if (m_CanRotate)
+		if(m_MousePressed)
 		{
-			if (Hzn::Input::keyPressed(Hzn::Key::Q))
-			{
-				m_Rotation -= (m_RotationSpeed * ts);
-			}
-			else if (Hzn::Input::keyPressed(Hzn::Key::E))
-			{
-				m_Rotation += (m_RotationSpeed * ts);
-			}
-		}
-
-		if (m_MouseDrag)
-		{
-			if (Hzn::Input::mouseButtonPressed(Hzn::Mouse::ButtonLeft))
-			{
-				auto [x, y] = Hzn::Input::getMousePos();
-				if (!mousePressed)
-				{
-					lastX = x;
-					lastY = y;
-					mousePressed = true;
-				}
-
-				float xOffset = lastX - (float)x;
-				float yOffset = lastY - (float)y;
-				lastX = x;
-				lastY = y;
-				HZN_CORE_WARN("({0}, {1})", x, y);
-				HZN_CORE_INFO("({0}, {1})", xOffset, yOffset);
-				m_Position.x += (xOffset * 0.4f * ts);
-				m_Position.y -= (yOffset * 0.4f * ts);
-			}
-			else {
-				mousePressed = false;
-			}
+			glm::vec2 currentMousePos{ Input::getMouseX(), Input::getMouseY() };
+			glm::vec2 mouseDelta = { lastMousePos.x - currentMousePos.x, currentMousePos.y - lastMousePos.y };
+			lastMousePos = currentMousePos;
+			m_Position += m_TranslationSpeed * 0.3f * ts * glm::vec3{ mouseDelta.x, mouseDelta.y, 0.0f };
 		}
 
 		m_Camera.setRotation(m_Rotation);
@@ -72,6 +41,7 @@ namespace Hzn
 		dispatcher.Dispatch<MouseScrolledEvent>(std::bind(&OrthographicCameraController::onMouseScrolled, this, std::placeholders::_1));
 		dispatcher.Dispatch<WindowResizeEvent>(std::bind(&OrthographicCameraController::onWindowResize, this, std::placeholders::_1));
 		dispatcher.Dispatch<MouseButtonPressedEvent>(std::bind(&OrthographicCameraController::onMouseButtonPressed, this, std::placeholders::_1));
+		dispatcher.Dispatch<MouseButtonReleasedEvent>(std::bind(&OrthographicCameraController::onMouseButtonReleased, this, std::placeholders::_1));
 	}
 
 
@@ -98,6 +68,18 @@ namespace Hzn
 	bool OrthographicCameraController::onMouseButtonPressed(MouseButtonPressedEvent& e)
 	{
 		/*HZN_CORE_INFO("{0}", e.GetMouseButton());*/
+		auto mouseButton = e.GetMouseButton();
+		if(mouseButton == Mouse::ButtonRight)
+		{
+			lastMousePos = { Input::getMouseX(), Input::getMouseY() };
+			m_MousePressed = true;
+		}
+		return false;
+	}
+
+	bool OrthographicCameraController::onMouseButtonReleased(MouseButtonReleasedEvent& e)
+	{
+		m_MousePressed = false;
 		return false;
 	}
 }

--- a/HorizonEngine/src/HorizonEngine/Camera/CameraController.h
+++ b/HorizonEngine/src/HorizonEngine/Camera/CameraController.h
@@ -34,8 +34,6 @@ namespace Hzn
 
 		virtual float getTranslationSpeed() const = 0;
 		virtual float getRotationSpeed() const = 0;
-		virtual void enableRotation(bool flag) = 0;
-		virtual void enableMouseDragMovement(bool flag) = 0;
 
 	private:
 		virtual bool onWindowResize(WindowResizeEvent& e) = 0;
@@ -75,26 +73,20 @@ namespace Hzn
 		virtual float getTranslationSpeed() const override { return m_TranslationSpeed; }
 		virtual float getRotationSpeed() const override { return m_RotationSpeed; }
 
-		virtual void enableRotation(bool flag) override { m_CanRotate = flag; }
-
-		virtual void enableMouseDragMovement(bool flag) override { m_MouseDrag = flag; }
-
 	private:
 		virtual bool onWindowResize(WindowResizeEvent& e) override;
 		virtual bool onMouseScrolled(MouseScrolledEvent& e) override;
 		virtual bool onMouseButtonPressed(MouseButtonPressedEvent& e) override;
+		bool onMouseButtonReleased(MouseButtonReleasedEvent& e);
 
 		OrthographicCamera m_Camera;
 		glm::vec3 m_Position = { 0.0f, 0.0f, 0.0f };
 		float m_Rotation = 0.0f;
 		float m_TranslationSpeed = 1.0f;
 		float m_RotationSpeed = 4.0f;
-		float lastX = 0.0f;
-		float lastY = 0.0f;
 
-		bool mousePressed = false;
-		bool m_MouseDrag = false;
-		bool m_CanRotate = false;
+		bool m_MousePressed = false;
+		glm::vec2 lastMousePos{0.0f, 0.0f};
 	};
 }
 


### PR DESCRIPTION
- Added Mouse Panning Support for camera movement (preliminary). Drag the Mouse holding the right button to move the editor camera.
- Updated the shortcut keys to switch between, Translation Rotation and Scale Gizmos.