### PR TITLE
Game Object Duplication and Ability to Add Components through UI.

### DIFF
--- a/HorizonEditor/include/EditorLayer.h
+++ b/HorizonEditor/include/EditorLayer.h
@@ -60,5 +60,5 @@ private:
 	//bool request_NewScene = false;
 	bool request_OpenScene = false;
 	//bool canCreateProject = false;
-	ImGuizmo::OPERATION m_GizmoType = ImGuizmo::OPERATION::NONE;
+	ImGuizmo::OPERATION m_GizmoType = ImGuizmo::OPERATION::TRANSLATE;
 };

--- a/HorizonEditor/src/EditorLayer.cpp
+++ b/HorizonEditor/src/EditorLayer.cpp
@@ -682,7 +682,7 @@ void EditorLayer::drawObjects(Hzn::GameObject& object)
 
 	auto& nameComponent = object.getComponent<Hzn::NameComponent>();
 
-	bool open = ImGui::TreeNodeEx(nameComponent.m_Name.c_str(), flags);
+	bool open = ImGui::TreeNodeEx((void*)(intptr_t)object.getObjectId(), flags, nameComponent.m_Name.c_str());
 
 	// Drag and drop
 	ImGuiDragDropFlags src_flags = ImGuiDragDropFlags_SourceNoDisableHover; // | ImGuiDragDropFlags_SourceNoHoldToOpenOthers;
@@ -734,6 +734,7 @@ void EditorLayer::drawObjects(Hzn::GameObject& object)
 
 void EditorLayer::openScene(const std::filesystem::path& filepath)
 {
+	m_SelectedObjectId = std::numeric_limits<uint32_t>::max();
 	Hzn::ProjectManager::openScene(filepath);
 	EditorData::s_Scene_Active = EditorData::m_Project_Active->getActiveScene();
 }

--- a/HorizonEngine/CMakeLists.txt
+++ b/HorizonEngine/CMakeLists.txt
@@ -52,7 +52,7 @@ set(HZN_SOURCE_FILES
 	"src/HorizonEngine/FileManagement/ProjectManager.cpp"
 	"src/HorizonEngine/FileManagement/Project.cpp"
 	"src/HorizonEngine/Scripting/ScriptEngine.cpp"
-	"src/HorizonEngine/Scripting/ScriptRegistry.cpp")
+	"src/HorizonEngine/Scripting/ScriptRegistry.cpp" "src/HorizonEngine/Components/Component.cpp" "src/HorizonEngine/SceneManagement/FunctionRegistry.cpp")
 
 set(HZN_HEADER_FILES
 	"HorizonEngine.h"
@@ -113,7 +113,7 @@ set(HZN_HEADER_FILES
 	"src/HorizonEngine/FileManagement/ProjectManager.h"
 	"src/HorizonEngine/FileManagement/Project.h"
 	"src/HorizonEngine/Scripting/ScriptEngine.h"
-	"src/HorizonEngine/Scripting/ScriptRegistry.h")
+	"src/HorizonEngine/Scripting/ScriptRegistry.h" "src/HorizonEngine/SceneManagement/FunctionRegistry.h")
 
 set(IMGUIZMO_FILES
 	"vendor/ImGuizmo/GraphEditor.cpp"

--- a/HorizonEngine/api_assets/shaders/TextureFragment.glsl
+++ b/HorizonEngine/api_assets/shaders/TextureFragment.glsl
@@ -5,12 +5,13 @@ layout (location = 1) out int f_EntityId;
 in vec4 v_Color;
 in vec2 v_TexCoord;
 in float v_TexSlot;
+in float v_TilingFactor;
 in flat int v_EntityId;
 
 uniform sampler2D u_Textures[32];
 
 void main()
 {
-	f_Color1 = texture(u_Textures[int(v_TexSlot)], v_TexCoord) * v_Color;
+	f_Color1 = texture(u_Textures[int(v_TexSlot)], v_TexCoord * v_TilingFactor) * v_Color;
 	f_EntityId = v_EntityId;
 }

--- a/HorizonEngine/api_assets/shaders/TextureVertex.glsl
+++ b/HorizonEngine/api_assets/shaders/TextureVertex.glsl
@@ -3,7 +3,8 @@ layout (location = 0) in vec3 a_Pos;
 layout (location = 1) in vec4 a_Color;
 layout (location = 2) in vec2 a_TexCoord;
 layout (location = 3) in float a_TexSlot;
-layout (location = 4) in int a_EntityId;
+layout (location = 4) in float a_TilingFactor;
+layout (location = 5) in int a_EntityId;
 
 uniform mat4 u_View;
 uniform mat4 u_Projection;
@@ -11,6 +12,7 @@ uniform mat4 u_Projection;
 out vec4 v_Color;
 out vec2 v_TexCoord;
 out float v_TexSlot;
+out float v_TilingFactor;
 out flat int v_EntityId;
 		
 void main()
@@ -19,5 +21,6 @@ void main()
 	v_TexCoord = a_TexCoord;
 	v_TexSlot = a_TexSlot;
 	v_EntityId = a_EntityId;
+	v_TilingFactor = a_TilingFactor;
 	gl_Position = u_Projection * u_View * vec4(a_Pos, 1.0f);
 }

--- a/HorizonEngine/src/HorizonEngine/App.cpp
+++ b/HorizonEngine/src/HorizonEngine/App.cpp
@@ -6,6 +6,8 @@
 
 #include "HorizonEngine/Renderer/Renderer.h"
 #include "HorizonEngine/Scripting/ScriptEngine.h"
+#include "HorizonEngine/Components/Component.h"
+#include "HorizonEngine/SceneManagement/FunctionRegistry.h"
 
 namespace Hzn
 {
@@ -26,6 +28,8 @@ namespace Hzn
 
 		m_ImguiLayer = new ImguiLayer();
 		addOverlay(m_ImguiLayer);
+
+		RegisterComponentFunctions(AllComponents{});
 	}
 
 	App::~App()

--- a/HorizonEngine/src/HorizonEngine/Components/Component.cpp
+++ b/HorizonEngine/src/HorizonEngine/Components/Component.cpp
@@ -1,0 +1,42 @@
+#include "pch.h"
+#include "Component.h"
+#include "HorizonEngine/SceneManagement/FunctionRegistry.h"
+
+namespace Hzn
+{
+	void addComponent(GameObject& obj, std::string& componentName)
+	{
+		if (componentName.find("struct Hzn::") == std::string::npos)
+		{
+			componentName = std::string("struct Hzn::") + componentName;
+		}
+
+		const auto& it = HasComponentFnTable.find(componentName);
+		if (it == HasComponentFnTable.end())
+		{
+			HZN_CORE_ERROR("Component Name Invalid!");
+			throw std::runtime_error("Component Name Invalid!");
+		}
+
+		if(!it->second(obj))
+		{
+			AddComponentFnTable[componentName](obj);
+		}
+	}
+
+	bool hasComponent(const GameObject& obj, std::string& componentName)
+	{
+		if (componentName.find("struct Hzn::") == std::string::npos)
+		{
+			componentName = std::string("struct Hzn::") + componentName;
+		}
+		
+		const auto& it = HasComponentFnTable.find(componentName);
+		if(it == HasComponentFnTable.end())
+		{
+			HZN_CORE_ERROR("Component Name Invalid!");
+			throw std::runtime_error("Component Name Invalid!");
+		}
+		return it->second(obj);
+	}
+}

--- a/HorizonEngine/src/HorizonEngine/Components/Component.h
+++ b/HorizonEngine/src/HorizonEngine/Components/Component.h
@@ -6,10 +6,9 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/matrix_decompose.hpp>
 #include <glm/gtc/type_ptr.hpp>
-#include <imgui.h>
+#include <entt/entt.hpp>
 
 #include "HorizonEngine/Camera/Camera.h"
-#include "HorizonEngine/SceneManagement/GameObject.h"
 #include "HorizonEngine/Renderer/Sprite.h"
 //#include "HorizonEngine/Utils/Math.h"
 //#include "HorizonEngine/AssetManagement/AssetManager.h"
@@ -19,9 +18,7 @@ namespace Hzn
 {
 	class AssetManager;
 	class Scene;
-
-	template<typename>
-	inline void display(const GameObject& obj) {}
+	class GameObject;
 
 	struct RelationComponent
 	{
@@ -99,7 +96,8 @@ namespace Hzn
 			: m_Translation(position), m_Scale(scale) {}
 		TransformComponent(const glm::vec3& position, const::glm::vec3& rotation, const glm::vec3& scale)
 			: m_Translation(position), m_Scale(scale), m_Rotation(rotation) {}
-		TransformComponent(const TransformComponent& rhs) = default;
+		TransformComponent(const TransformComponent& rhs)
+			: m_Translation(rhs.m_Translation), m_Scale(rhs.m_Scale), m_Rotation(rhs.m_Rotation) {} 
 		TransformComponent& operator=(const TransformComponent& rhs) = default;
 		~TransformComponent() = default;
 
@@ -186,6 +184,23 @@ namespace Hzn
 			ar(m_Camera, m_Primary);
 		}
 	};
+
+	struct ScriptComponent
+	{
+		ScriptComponent() = default;
+		ScriptComponent(const char* name) : scriptName(name) {}
+		~ScriptComponent() = default;
+		const char* scriptName = "";
+	};
+
+	template<typename... Component>
+	struct ComponentGroup {};
+
+	using AllComponents = ComponentGroup<NameComponent, RelationComponent, TransformComponent, RenderComponent, CameraComponent>;
+	using SelectableComponents = ComponentGroup<RenderComponent, CameraComponent, ScriptComponent>;
+
+	void addComponent(GameObject& obj, std::string& componentName);
+	bool hasComponent(const GameObject& obj, std::string& componentName);
 }
 
 #endif

--- a/HorizonEngine/src/HorizonEngine/Renderer/Renderer2D.cpp
+++ b/HorizonEngine/src/HorizonEngine/Renderer/Renderer2D.cpp
@@ -14,6 +14,7 @@ namespace Hzn
 		glm::vec4 color;
 		glm::vec2 texCoord;
 		float texSlot;
+		float tilingFactor;
 		int entityId;
 	};
 
@@ -100,6 +101,7 @@ namespace Hzn
 			{Hzn::ShaderDataType::Vec4f, "a_Color"},
 			{Hzn::ShaderDataType::Vec2f, "a_TexCoord"},
 			{Hzn::ShaderDataType::Float, "a_TexSlot"},
+			{Hzn::ShaderDataType::Float, "a_TilingFactor"},
 			{Hzn::ShaderDataType::Int, "a_EntityId"}
 		};
 
@@ -218,6 +220,7 @@ namespace Hzn
 			data.ptr->color = color;
 			data.ptr->texCoord = data.quadTexCoords[i];
 			data.ptr->texSlot = textureIndex;
+			data.ptr->tilingFactor = 1.0f;
 			data.ptr->entityId = id;
 			data.ptr++;
 		}
@@ -262,6 +265,7 @@ namespace Hzn
 			data.ptr->color = color;
 			data.ptr->texCoord = data.quadTexCoords[i];
 			data.ptr->texSlot = textureIndex;
+			data.ptr->tilingFactor = 1.0f;
 			data.ptr->entityId = id;
 			data.ptr++;
 		}
@@ -306,6 +310,7 @@ namespace Hzn
 			data.ptr->color = color;
 			data.ptr->texCoord = sprite->getTexCoords()[i];
 			data.ptr->texSlot = textureIndex;
+			data.ptr->tilingFactor = 1.0f;
 			data.ptr->entityId = id;
 			data.ptr++;
 		}

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/FunctionRegistry.cpp
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/FunctionRegistry.cpp
@@ -1,0 +1,10 @@
+#include "pch.h"
+#include "FunctionRegistry.h"
+
+namespace Hzn
+{
+	class GameObject;
+
+	std::unordered_map<std::string, std::function<void(GameObject&)>> AddComponentFnTable;
+	std::unordered_map<std::string, std::function<bool(const GameObject&)>> HasComponentFnTable;
+}

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/FunctionRegistry.h
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/FunctionRegistry.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#ifndef HZN_FUNCTION_REGISTRY_H
+#define HZN_FUNCTION_REGISTRY_H
+
+#include "HorizonEngine/Components/Component.h"
+#include "GameObject.h"
+
+namespace Hzn
+{
+	extern std::unordered_map<std::string, std::function<void(GameObject&)>> AddComponentFnTable;
+	extern std::unordered_map<std::string, std::function<bool(const GameObject&)>> HasComponentFnTable;
+
+	template<typename... Component>
+	void RegisterComponentFunctions(ComponentGroup<Component...>)
+	{
+		([&]
+			{
+				AddComponentFnTable[typeid(Component).name()] = &GameObject::addComponent<Component>;
+				HasComponentFnTable[typeid(Component).name()] = &GameObject::hasComponent<Component>;
+			}(), ...);
+	}
+};
+
+#endif

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/GameObject.cpp
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/GameObject.cpp
@@ -8,7 +8,7 @@ namespace Hzn
 {
 	static std::unordered_set<uint32_t> allUnder;
 
-	void GameObject::setParent(GameObject& obj) const 
+	void GameObject::setParent(GameObject& obj)
 	{
 		isValid();
 
@@ -17,6 +17,7 @@ namespace Hzn
 		auto& relationComponent = m_Scene->m_Registry.get<RelationComponent>(m_ObjectId);
 
 		if (obj) {
+			auto& objrelationComponent = m_Scene->m_Registry.get<RelationComponent>(obj.m_ObjectId);
 			if (!isAncestorOf(obj)) {
 				if (getComponent<Hzn::RelationComponent>().hasParent()) {
 					getParent().removeChild(*this);
@@ -89,7 +90,7 @@ namespace Hzn
 		return m_Scene->m_Registry.get<RelationComponent>(m_ObjectId).m_ChildCount;
 	}
 
-	void GameObject::addChild(const GameObject& obj)
+	void GameObject::addChild(GameObject& obj)
 	{
 		// if this game object itself is valid.
 		isValid();
@@ -100,6 +101,11 @@ namespace Hzn
 		}
 		// if 'obj' and 'this' are the same objects.
 		if (obj == *this) return;
+
+		if(obj.getParent())
+		{
+			obj.getParent().removeChild(obj);
+		}
 
 		auto& relationComponent = m_Scene->m_Registry.get<RelationComponent>(m_ObjectId);
 		auto curr = relationComponent.m_FirstChild;
@@ -143,7 +149,7 @@ namespace Hzn
 		childTransform.m_Scale = scale;
 	}
 
-	void GameObject::removeChild(const GameObject& obj)
+	void GameObject::removeChild(GameObject& obj)
 	{
 		isValid();
 		if (!sameScene(obj))
@@ -234,6 +240,7 @@ namespace Hzn
 		auto clonedObject = duplicate();
 		auto& clonedRel = m_Scene->m_Registry.get<RelationComponent>(clonedObject.m_ObjectId);
 		auto& originalParentRel = getParent().getComponent<RelationComponent>();
+		originalParentRel.m_ChildCount++;
 		auto curr = originalParentRel.m_FirstChild;
 		auto prev = curr;
 
@@ -274,6 +281,7 @@ namespace Hzn
 			}
 			prev = clonedChild.m_ObjectId;
 			childRel.m_Parent = clonedParent.m_ObjectId;
+			parentRel.m_ChildCount++;
 		}
 
 		return clonedParent;

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/GameObject.h
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/GameObject.h
@@ -61,15 +61,15 @@ namespace Hzn
 
 		uint32_t getObjectId() const { return entt::to_integral(m_ObjectId); }
 
-		void setParent(GameObject& obj) const;
+		void setParent(GameObject& obj);
 		GameObject getParent() const;
 		GameObject getNextSibling() const;
 		GameObject getPrevSibling() const;
 		std::vector<GameObject> getChildren() const;
 		size_t getChildCount() const;
 		std::vector<GameObject> getChildrenAll() const;
-		void addChild(const GameObject& obj);
-		void removeChild(const GameObject& obj);
+		void addChild(GameObject& obj);
+		void removeChild(GameObject& obj);
 		bool isAncestorOf(const GameObject& obj) const;
 		glm::mat4 getTransform() const;
 		GameObject duplicateAsChild();

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/SceneManager.cpp
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/SceneManager.cpp
@@ -2,10 +2,10 @@
 
 #include <cereal/archives/json.hpp>
 
-#include "SceneManager.h"
 #include "Scene.h"
-#include "Components/Component.h"
-#include "HorizonEngine/FileManagement/ProjectManager.h"
+#include "GameObject.h"
+#include "HorizonEngine/Components/Component.h"
+#include "SceneManager.h"
 
 namespace Hzn
 {
@@ -100,7 +100,9 @@ namespace Hzn
 		camera.addComponent<Hzn::TransformComponent>();
 
 		object0.addChild(object1);
-		object1.addChild(object3);
+		object1.addChild(object3); // object3 local transform will change. 
+
+		object0.duplicate();
 	}
 
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dropdown to build the project.
 the [CMakePresets.json](CMakePresets.json) file. *x64-debug* and *x64-release*. The command below would configure and generate the project based on the preset
 provided to the `--preset` option. Command: `cmake --preset x64-debug`
         3. Run the following command to build the project: `cd bin\build\x64-debug` and `cmake --build .`
-        4. Run the following command to run the client application: `cd HznApplication\Debug` and then `HznApplication.exe` (or the following for powershell `cd HznApplication\Debug` and then `.\HznApplication.exe`).
+        4. Run the following command to run the client application: `cd HorizonEditor\Debug` and then `.\HznEditor.exe`.
         5. (Grouped up):
 ```
 cmake --preset x64-debug
@@ -56,15 +56,15 @@ cd HorizonEditor\Debug
 Alternatively, you can open the vcpkg directory in the project, through
 command line and write `vcpkg search <package-name>`
 to find out the name of any dependency.
-2. To add a dependency, add it to the **dependencies** field in the
+1. To add a dependency, add it to the **dependencies** field in the
 [vcpkg.json](vcpkg.json) file with the appropriate name.
-3. Update the appropriate *CMakeLists.txt* file with commands of
+1. Update the appropriate *CMakeLists.txt* file with commands of
 following format:
 ```
 find_package(<dependency-name> CONFIG REQUIRED)
 target_link_libraries(<target-name> PUBLIC <dependency-name>)
 ```
-4. A hint is provided as to what the appropriate names to be supplied
+1. A hint is provided as to what the appropriate names to be supplied
 to the above two commands are upon configuring the *CMakeLists.txt* file
 (the configuration first checks (if already installed) and installs the packages added to [vcpkg.json](vcpkg.json)
 and then continues configuring the rest of the project).


### PR DESCRIPTION
- Game Objects can now be duplicated. Duplicating a Game Object, duplicates all the hierarchy under it.
- If a Game Object that is an intermediate node is duplicated, then the cloned object is added as a sibling to the game object.
- Components can now be added to Game Objects through the editor.